### PR TITLE
start jenkins using CMD

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,4 +75,4 @@ EXPOSE 8080
 VOLUME /var/jenkins_home
 WORKDIR /home/jenkins
 # Run shell by default for container testing/development
-CMD bash -l
+CMD /usr/local/bin/jenkins


### PR DESCRIPTION
I think the main purpose of the docker container is to run jenkins. So I think we should start it by default. There are other options for debugging.