### PR TITLE
set NEMO_BUILD_THREADS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,7 @@ node {
     def stdenv = [
         "GAPROOT=${workspace}/gap",
         "NEMO_SOURCE_BUILD=1",
+        "NEMO_BUILD_THREADS=${jobs}",
         "JULIA_DEPOT_PATH=${workspace}/jenv/pkg",
         "JULIA_PROJECT=${workspace}/jenv/proj",
         "POLYMAKE_CONFIG=${workspace}/local/bin/polymake-config",


### PR DESCRIPTION
As of https://github.com/Nemocas/Nemo.jl/commit/13222e244e72f77e06e1812b2e6cc71ede6a1de5 Nemo allows to specify the number of threads to use when building C dependencies using the environment variable `NEMO_BUILD_THREADS`. This pull requests defined this environment variable using `BUILDJOBS`. This will hopefully allow us to speed up tests on multi core machines.