### PR TITLE
change HEARTBEAT_CHECK_INTERVAL

### DIFF
--- a/docker/bin/jenkins
+++ b/docker/bin/jenkins
@@ -1,2 +1,2 @@
 #!/bin/sh
-java -jar /usr/share/jenkins/jenkins.war "$@"
+java -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=600 -jar /usr/share/jenkins/jenkins.war "$@"


### PR DESCRIPTION
I ran into problems similar to those reported in https://bugs.eclipse.org/bugs/show_bug.cgi?id=533709. They occur while the Oscar packages are being build. I guess this due to some kind of timeout issue. So I applied the suggested fix. I hope this resolves this issue without side effects.