### PR TITLE
test NemoLinearAlgebraForCAP

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,6 +109,10 @@ node {
                     git url: "https://github.com/homalg-project/OscarForHomalg.git",
                         branch: "master"
                 }
+                dir("NemoLinearAlgebraForCAP") {
+                    git url: "https://github.com/sebastianpos/NemoLinearAlgebraForCAP",
+                        branch: "master"
+                }
             } else {
                 // skip preparation
 		echo "Skipping preparation stage."
@@ -167,7 +171,9 @@ node {
 		    def GAP_jl_PATH = sh(returnStdout: true,
 			script: "julia meta/gappath.jl").trim()
 		    sh script: "sh meta/install-gap-pkg.sh ${workspace}/OscarForHomalg",
-			label: "Install OscarForHomalg packages in GAP pkg folder"
+			label: "Install OscarForHomalg package in GAP pkg folder"
+		    sh script: "sh meta/install-gap-pkg.sh ${workspace}/NemoLinearAlgebraForCAP",
+			label: "Install NemoLinearAlgebraForCAP package in GAP pkg folder"
 		    sh script: "sh meta/install-gap-pkg.sh ${GAP_jl_PATH}/pkg/GAPJulia",
 			label: "Install GAPJulia packages from GAP.jl in GAP pkg folder"
 		}

--- a/tests/config.py
+++ b/tests/config.py
@@ -11,4 +11,5 @@
     Test(name="JuliaInterface", script="test-JuliaInterface.sh"),
     Test(name="JuliaExperimental", script="test-JuliaExperimental.sh"),
     # Test(name="Oscar.jl", script = "test-oscar.sh"),
+    Test(name="NemoLinearAlgebraForCAP", script = "test-NemoLinearAlgebraForCAP.sh"),
 ]

--- a/tests/test-NemoLinearAlgebraForCAP.sh
+++ b/tests/test-NemoLinearAlgebraForCAP.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+cd gap/pkg/NemoLinearAlgebraForCAP
+export TERM="dumb"
+make test
+


### PR DESCRIPTION
This adds tests for the GAP package [NemoLinearAlgebraForCAP](https://github.com/sebastianpos/NemoLinearAlgebraForCAP).
It uses the GAP package `JuliaExperimental` from [GAP.jl](https://github.com/oscar-system/GAP.jl/) to access [Nemo](https://github.com/Nemocas/Nemo.jl/) and [Hecke](https://github.com/thofma/Hecke.jl) from GAP.
The aim here is to provide an additional integration test.