### PR TITLE
use Julia 1.2 by default

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -10,7 +10,7 @@
         <hudson.model.StringParameterDefinition>
           <name>JULIA_VERSION</name>
           <description>Which branch/version of Julia to build? (Must be a valid Git ref.)</description>
-          <defaultValue>release-1.1</defaultValue>
+          <defaultValue>release-1.2</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>


### PR DESCRIPTION
As Julia 1.2 was released, I think we should by default test against it rather than Julia 1.1.